### PR TITLE
create a base image with it.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM centos:centos6
+MAINTAINER Bas Meijer <bas.meijer@me.com>
+
+RUN mkdir -p /tmp/ansible/roles/base_miniconda
+RUN yum install -y epel-release && \
+    yum install -y ansible && \
+    yum clean all
+COPY ./files/hosts /etc/ansible/hosts
+ADD . /tmp/ansible/roles/base_miniconda
+COPY ./molecule/default/provision.yml ./molecule/default/vars.yml /tmp/ansible/
+RUN cd /tmp/ansible && ansible-playbook provision.yml
+ENV PATH /opt/conda/envs/env/bin:$PATH

--- a/files/hosts
+++ b/files/hosts
@@ -1,0 +1,2 @@
+[local]
+localhost ansible_host=127.0.0.1 ansible_connection=local

--- a/molecule/default/provision.yml
+++ b/molecule/default/provision.yml
@@ -1,0 +1,39 @@
+---
+- hosts: all
+  vars:
+    install_miniconda: true
+    miniconda_dir: "{{ miniconda_parent_dir }}/conda"
+  vars_files:
+    - vars.yml
+  roles:
+    - role: base_miniconda
+
+  post_tasks:
+    - name: Create conda environments
+      conda:
+        executable: "{{ miniconda_dir }}/bin/conda"
+        name: "python={{ item.python }}"
+        environment: "{{ item.pyenv }}"
+      with_items: "{{ miniconda_envs }}"
+      when:
+        - miniconda_envs is defined
+      tags:
+        - miniconda
+    
+    - name: Configure conda environments
+      conda:
+        executable: "{{ miniconda_dir }}/bin/conda"
+        environment: "{{ item.pyenv }}"
+        channels: "{{ miniconda_channels }}"
+        name: "{{ miniconda_packages }}"
+        state: present
+      with_items: "{{ miniconda_envs }}"
+      when:
+        - miniconda_envs is defined
+      tags:
+        - miniconda
+    
+    - name: Cleanup Conda
+      command: "{{ miniconda_dir }}/bin/conda clean --yes --all"
+      tags:
+        - miniconda

--- a/molecule/default/provision.yml
+++ b/molecule/default/provision.yml
@@ -19,7 +19,7 @@
         - miniconda_envs is defined
       tags:
         - miniconda
-    
+
     - name: Configure conda environments
       conda:
         executable: "{{ miniconda_dir }}/bin/conda"
@@ -32,7 +32,7 @@
         - miniconda_envs is defined
       tags:
         - miniconda
-    
+
     - name: Cleanup Conda
       command: "{{ miniconda_dir }}/bin/conda clean --yes --all"
       tags:

--- a/molecule/default/vars.yml
+++ b/molecule/default/vars.yml
@@ -1,0 +1,30 @@
+---
+
+miniconda_python_ver: 3
+
+miniconda_dir: "{{ miniconda_parent_dir }}/conda"
+miniconda_envs:
+  - pyenv: "{{ miniconda_dir }}/envs/py27_64"
+    python: "2.7"
+  - pyenv: "{{ miniconda_dir }}/envs/py36_64"
+    python: "3.6"
+  - pyenv: "{{ miniconda_dir }}/envs/py37_64"
+    python: "3.7"
+
+miniconda_packages:
+  - future
+  - pytest
+  - ipython
+  - jupyter
+  - pandas
+  - numpy
+  - scipy
+  - matplotlib
+  - bokeh
+  - doxygen=1.8.14 # hardcode to 1.8.14 due to bug in 1.8.16
+  - graphviz # required for doxygen
+  - mkdocs
+miniconda_channels:
+  - main
+  - conda-forge
+

--- a/molecule/default/vars.yml
+++ b/molecule/default/vars.yml
@@ -21,10 +21,9 @@ miniconda_packages:
   - scipy
   - matplotlib
   - bokeh
-  - doxygen=1.8.14 # hardcode to 1.8.14 due to bug in 1.8.16
-  - graphviz # required for doxygen
+  - doxygen=1.8.14  # hardcode to 1.8.14 due to bug in 1.8.16
+  - graphviz  # required for doxygen
   - mkdocs
 miniconda_channels:
   - main
   - conda-forge
-


### PR DESCRIPTION
Miniconda can be quite bulky to build all the times. 
Now you can create a base container with `docker build -t base_miniconda:1.2.6`