### PR TITLE
Skip installing conda environments if conda is missing.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,13 @@
   include_tasks: install.yml
   when: install_miniconda is defined and install_miniconda|bool
 
+- name: check presence of Conda
+  stat:
+    path: "{{ miniconda_dir }}/bin/conda"
+  register: conda_executable
+
 - name: create conda environments when miniconda_envs is defined
   include_tasks: conda.yml
-  when: miniconda_envs is defined
+  when:
+    - conda_executable.stat.exists|bool
+    - miniconda_envs is defined


### PR DESCRIPTION
Adding a test to see if conda is present before trying to create environments.